### PR TITLE
feat: add custom format presets management in SummaryStep

### DIFF
--- a/src/hooks/useFormatPresets.ts
+++ b/src/hooks/useFormatPresets.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { localStorage as storage } from '../utils/storage';
+
+export interface FormatPreset {
+  id: string;
+  name: string;
+  prompt: string;
+  isCustom?: boolean;
+}
+
+interface StoredPreset {
+  id: string;
+  name: string;
+  prompt: string;
+}
+
+const createPresetId = () => {
+  if (typeof window !== 'undefined' && window.crypto?.randomUUID) {
+    return `custom-${window.crypto.randomUUID()}`;
+  }
+  return `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+};
+
+const toStoredPresets = (presets: FormatPreset[]): StoredPreset[] =>
+  presets.map(({ id, name, prompt }) => ({ id, name, prompt }));
+
+const fromStoredPresets = (presets: StoredPreset[]): FormatPreset[] =>
+  presets.map((preset) => ({ ...preset, isCustom: true }));
+
+export function useFormatPresets(basePresets: FormatPreset[] = []) {
+  const [customPresets, setCustomPresets] = useState<FormatPreset[]>([]);
+
+  useEffect(() => {
+    const stored = storage.getSummaryPromptPresets();
+    if (stored.length > 0) {
+      setCustomPresets(fromStoredPresets(stored));
+    }
+  }, []);
+
+  const persistCustomPresets = useCallback((presets: FormatPreset[]) => {
+    storage.saveSummaryPromptPresets(toStoredPresets(presets));
+  }, []);
+
+  const addCustomPreset = useCallback((name: string, prompt: string): FormatPreset => {
+    const trimmedName = name.trim();
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedName || !trimmedPrompt) {
+      throw new Error('プリセット名とプロンプトを入力してください');
+    }
+    const created: FormatPreset = { id: createPresetId(), name: trimmedName, prompt: trimmedPrompt, isCustom: true };
+    setCustomPresets((prev) => {
+      const next = [...prev, created];
+      persistCustomPresets(next);
+      return next;
+    });
+    return created;
+  }, [persistCustomPresets]);
+
+  const removeCustomPreset = useCallback((id: string) => {
+    setCustomPresets((prev) => {
+      const next = prev.filter((preset) => preset.id !== id);
+      persistCustomPresets(next);
+      return next;
+    });
+  }, [persistCustomPresets]);
+
+  const updateCustomPreset = useCallback((id: string, updates: { name?: string; prompt?: string }): FormatPreset => {
+    let updatedPreset: FormatPreset | null = null;
+    setCustomPresets((prev) => {
+      const index = prev.findIndex((preset) => preset.id === id);
+      if (index === -1) {
+        updatedPreset = null;
+        return prev;
+      }
+      const next = [...prev];
+      const current = next[index];
+      const updated: FormatPreset = {
+        ...current,
+        name: updates.name !== undefined ? updates.name.trim() : current.name,
+        prompt: updates.prompt !== undefined ? updates.prompt.trim() : current.prompt
+      };
+      if (!updated.name || !updated.prompt) {
+        throw new Error('プリセット名とプロンプトは必須です');
+      }
+      next[index] = updated;
+      updatedPreset = updated;
+      persistCustomPresets(next);
+      return next;
+    });
+    if (!updatedPreset) {
+      throw new Error('指定したプリセットが見つかりませんでした');
+    }
+    return updatedPreset;
+  }, [persistCustomPresets]);
+
+  const presets = useMemo(() => {
+    const base = Array.isArray(basePresets) ? basePresets : [];
+    return [...base, ...customPresets];
+  }, [basePresets, customPresets]);
+
+  return {
+    presets,
+    customPresets,
+    addCustomPreset,
+    removeCustomPreset,
+    updateCustomPreset,
+  };
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,6 +4,7 @@ const STORAGE_KEYS = {
   CUSTOM_PROMPT: 'audioSplit_customPrompt',
   SUMMARY_CUSTOM_PROMPT: 'audioSplit_summaryCustomPrompt',
   SUMMARY_BACKGROUND_INFO: 'audioSplit_summaryBackgroundInfo',
+  SUMMARY_PROMPT_PRESETS: 'audioSplit_summaryPromptPresets',
   API_KEY_HASH: 'audioSplit_apiKeyHash',
   API_ENDPOINT: 'audioSplit_apiEndpoint',
   SETTINGS: 'audioSplit_settings'
@@ -173,6 +174,33 @@ export const localStorage = {
   
   clearSummaryBackgroundInfo: (): void => {
     window.localStorage.removeItem(STORAGE_KEYS.SUMMARY_BACKGROUND_INFO);
+  },
+
+  // まとめ用プリセット
+  saveSummaryPromptPresets: (presets: Array<{ id: string; name: string; prompt: string }>): void => {
+    if (!presets || presets.length === 0) {
+      window.localStorage.removeItem(STORAGE_KEYS.SUMMARY_PROMPT_PRESETS);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEYS.SUMMARY_PROMPT_PRESETS, JSON.stringify(presets));
+  },
+
+  getSummaryPromptPresets: (): Array<{ id: string; name: string; prompt: string }> => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEYS.SUMMARY_PROMPT_PRESETS);
+      if (!stored) return [];
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter((preset) =>
+        preset && typeof preset.id === 'string' && typeof preset.name === 'string' && typeof preset.prompt === 'string'
+      );
+    } catch {
+      return [];
+    }
+  },
+
+  clearSummaryPromptPresets: (): void => {
+    window.localStorage.removeItem(STORAGE_KEYS.SUMMARY_PROMPT_PRESETS);
   },
   
   // アプリ設定


### PR DESCRIPTION
- Introduced a new hook `useFormatPresets` to manage custom format presets.
- Updated `SummaryStep` component to support adding, editing, and deleting custom presets.
- Enhanced UI to allow users to create and manage their own summary presets.
- Implemented functionality to save and retrieve presets from local storage.
- Updated `TranscribePage` to integrate manual transcription uploads and display relevant summaries.
- Added drag-and-drop support for uploading transcription files.
- Improved error handling and user feedback for transcription import processes.